### PR TITLE
Remove pip package URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pycountry",
-    version="22.3.7",
+    version="22.1.12",
     author="Christian Theune",
     author_email="ct@flyingcircus.io",
     description="ISO country, subdivision, language, currency and script "

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pycountry",
-    version="22.1.12",
+    version="22.1.13",
     author="Christian Theune",
     author_email="ct@flyingcircus.io",
     description="ISO country, subdivision, language, currency and script "

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pycountry",
-    version="22.3.6.dev0",
+    version="22.3.7",
     author="Christian Theune",
     author_email="ct@flyingcircus.io",
     description="ISO country, subdivision, language, currency and script "
@@ -19,7 +19,6 @@ setup(
         + "\n"
         + open("HISTORY.txt", encoding="utf-8").read()
     ),
-    url="https://github.com/flyingcircusio/pycountry",
     license="LGPL 2.1",
     keywords="country subdivision language currency iso 3166 639 4217 "
     "15924 3166-2",


### PR DESCRIPTION
The version + URL differences in in setup.py is mucking around with our pip version resolution across different AMIs - removing them here will encourage pip to behave. 